### PR TITLE
Bump service-update to 1.1.8 with config integration and chart filtering

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "*-v[0-9]+.[0-9]+.[0-9]+*"
+  pull_request:
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io
@@ -25,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -32,7 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        if: startsWith(github.ref_name, matrix.job)
+        if: github.event_name == 'push' && startsWith(github.ref_name, matrix.job)
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -41,7 +45,7 @@ jobs:
             type=match,pattern=${{ matrix.job }}-(v.+),group=1
 
       - name: Build and push Docker image
-        if: startsWith(github.ref_name, matrix.job)
+        if: github.event_name == 'push' && startsWith(github.ref_name, matrix.job)
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -49,3 +53,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build Docker image (PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./jobs/${{ matrix.job }}/Dockerfile
+          push: false

--- a/jobs/service_update/chart_utils.py
+++ b/jobs/service_update/chart_utils.py
@@ -1,9 +1,12 @@
 import io
+import re
 import yaml
 import logging
 import requests
 from natsort import natsorted
 from notifications import send_notification
+
+STABLE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(-stable)?$")
 
 
 def check_for_chart_update(chart_file: dict):
@@ -26,12 +29,7 @@ def check_for_chart_update(chart_file: dict):
             chart["version"]
             for chart in repository_index["entries"].get(chart_name, [])
         ]
-        remote_versions = list(
-            filter(
-                lambda x: "dev" not in x and "alpha" not in x and "beta" not in x,
-                remote_versions,
-            )
-        )
+        remote_versions = [v for v in remote_versions if STABLE_VERSION_RE.match(v)]
         remote_versions = list(natsorted(remote_versions, reverse=True))
         if remote_versions and remote_versions[0] != dependency["version"]:
             original_version = dependency["version"]
@@ -66,11 +64,14 @@ def check_for_helm_chart_update(kustomize_file: dict):
     ]
     remote_versions = list(
         filter(
-            lambda x: "dev" not in x and "alpha" not in x and "beta" not in x,
+            lambda x: "dev" not in x and "rc" not in x and "alpha" not in x and "beta" not in x,
             remote_versions,
         )
     )
     remote_versions = list(natsorted(remote_versions, reverse=True))
+    if not remote_versions:
+        logging.warning("No stable versions found for %s", deployed_chart.get("name"))
+        return
     if remote_versions[0] != deployed_chart["version"]:
         original_version = deployed_chart["version"]
         kustomize_file["helmCharts"][0]["version"] = remote_versions[0]

--- a/jobs/service_update/config_utils.py
+++ b/jobs/service_update/config_utils.py
@@ -1,0 +1,31 @@
+import logging
+import os
+
+from notifications import send_notification
+from retry_session import RetrySession
+
+CONFIG_SERVICE_URL = os.getenv(
+    "CONFIG_SERVICE_URL",
+    "http://configuration-setting-service.application.svc.cluster.local:8080",
+)
+
+
+def get_setting(section: str, name: str) -> str | None:
+    url = f"{CONFIG_SERVICE_URL}/configuration_setting/{section}/{name}"
+    try:
+        session = RetrySession()
+        response = session.get(url)
+        response.raise_for_status()
+        return response.json()["value"]
+    except Exception as e:
+        error_message = f"Error fetching config setting {section}/{name}: {e}"
+        logging.error(error_message)
+        send_notification(error_message)
+        return None
+
+
+def get_ignored_images() -> set[str]:
+    value = get_setting("service_update", "ignored_images")
+    if not value:
+        return set()
+    return {img.strip() for img in value.split(",") if img.strip()}

--- a/jobs/service_update/file_utils.py
+++ b/jobs/service_update/file_utils.py
@@ -52,8 +52,8 @@ def find_chart_updates(files):
     return updates
 
 
-def find_image_updates(files):
-    updates = deployment_files_find_image_updates(files)
+def find_image_updates(files, ignored_images: set[str]):
+    updates = deployment_files_find_image_updates(files, ignored_images)
     return updates
 
 
@@ -90,13 +90,13 @@ def chart_files_find_chart_updates(chart_files):
     return files_needing_updates
 
 
-def deployment_files_find_image_updates(deployment_files):
+def deployment_files_find_image_updates(deployment_files, ignored_images: set[str]):
     files_needing_updates = []
     for deployment_file in deployment_files:
         file_stream = io.BytesIO(deployment_file.decoded_content)
         try:
             parsed_file = yaml.safe_load(file_stream)
-            updated_file = check_for_image_update(parsed_file)
+            updated_file = check_for_image_update(parsed_file, ignored_images)
             if updated_file is not None:
                 updated_file["path"] = deployment_file.path
                 updated_file["sha"] = deployment_file.sha

--- a/jobs/service_update/filters.py
+++ b/jobs/service_update/filters.py
@@ -1,13 +1,6 @@
-IGNORED_IMAGE_NAMES = {
-    "postgres",
-    "mariadb",
-    "mysql",
-}
-
-
-def is_ignored_image(image_name: str) -> bool:
+def is_ignored_image(image_name: str, ignored_images: set[str]) -> bool:
     base_name = image_name.split("/")[-1]
-    return base_name in IGNORED_IMAGE_NAMES
+    return base_name in ignored_images
 
 
 def image_updates_with_minor_or_patch_filter(image_update):

--- a/jobs/service_update/image_utils.py
+++ b/jobs/service_update/image_utils.py
@@ -8,12 +8,12 @@ from retry_session import RetrySession
 from filters import is_ignored_image
 
 
-def check_for_image_update(deployment_file: dict):
+def check_for_image_update(deployment_file: dict, ignored_images: set[str]):
     containers = deployment_file["spec"]["template"]["spec"]["containers"]
     for container in containers:
         image_name, current_tag = parse_image(container["image"])
-        if is_ignored_image(image_name):
-            logging.info("Skipping database image %s", image_name)
+        if is_ignored_image(image_name, ignored_images):
+            logging.info("Skipping ignored image %s", image_name)
             continue
         new_tag = get_latest_image_tag(image_name)
         if new_tag is None:
@@ -121,9 +121,15 @@ def fetch_quay_tags(image_name: str):
         return None
 
 
+PRE_RELEASE_KEYWORDS = ("rc", "alpha", "beta")
+
+
 def filter_and_sort_tags(tags):
     regex = re.compile(r"^v?\d+\.\d+\.\d+(?:\.\d+)?$")
-    filtered_tags = [tag for tag in tags if regex.match(tag)]
+    filtered_tags = [
+        tag for tag in tags
+        if regex.match(tag) and not any(kw in tag.lower() for kw in PRE_RELEASE_KEYWORDS)
+    ]
     if not filtered_tags:
         return None
     return natsorted(filtered_tags, key=lambda x: x, reverse=True)

--- a/jobs/service_update/main.py
+++ b/jobs/service_update/main.py
@@ -13,6 +13,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 from notifications import send_notification
+from config_utils import get_ignored_images
 from file_utils import (
     get_files,
     find_helm_updates,
@@ -53,9 +54,12 @@ def main():
             argo_repo, repo_contents
         )
 
+        logger.info("Fetching ignored images from config service")
+        ignored_images = get_ignored_images()
+
         logger.info("Checking for updates")
         helm_updates = find_helm_updates(kustomize_files)
-        image_updates = find_image_updates(deployment_files)
+        image_updates = find_image_updates(deployment_files, ignored_images)
         chart_updates = find_chart_updates(chart_files)
 
         if not (helm_updates or image_updates or chart_updates):

--- a/jobs/service_update/pyproject.toml
+++ b/jobs/service_update/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "service-update"
-version = "1.1.7"
+version = "1.1.8"
 description = "Service update job for k8s deployments"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
…oved chart filtering

- Fetch ignored images list from configuration-setting-service at runtime instead of using a hardcoded set, via new config_utils module
- Filter pre-release chart versions using a strict regex (X.Y.Z or X.Y.Z-stable) instead of case-sensitive keyword matching, fixing rc versions slipping through
- Filter rc/alpha/beta tags from image updates explicitly
- Add missing empty-version-list guard in check_for_helm_chart_update
- Fix uv pip install by switching jobs-common source from workspace to path reference