### PR TITLE
Apply ignored list to helm and chart update paths, not just image updates

### DIFF
--- a/jobs/service_update/chart_utils.py
+++ b/jobs/service_update/chart_utils.py
@@ -9,10 +9,13 @@ from notifications import send_notification
 STABLE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(-stable)?$")
 
 
-def check_for_chart_update(chart_file: dict):
+def check_for_chart_update(chart_file: dict, ignored_images: set[str]):
     dependencies = chart_file.get("dependencies", [])
     for dependency in dependencies:
         chart_name = dependency["name"]
+        if chart_name in ignored_images:
+            logging.info("Skipping ignored chart %s", chart_name)
+            continue
         chart_repo = dependency["repository"]
         if not chart_repo.endswith("/"):
             chart_repo += "/"
@@ -42,9 +45,12 @@ def check_for_chart_update(chart_file: dict):
             }
 
 
-def check_for_helm_chart_update(kustomize_file: dict):
+def check_for_helm_chart_update(kustomize_file: dict, ignored_images: set[str]):
     deployed_chart = kustomize_file["helmCharts"][0]
     if deployed_chart.get("namespace") == "databases":
+        return
+    if deployed_chart.get("name") in ignored_images:
+        logging.info("Skipping ignored chart %s", deployed_chart.get("name"))
         return
     chart_repo = deployed_chart["repo"]
     if not chart_repo.endswith("/"):

--- a/jobs/service_update/file_utils.py
+++ b/jobs/service_update/file_utils.py
@@ -42,13 +42,13 @@ def find_kustomize_and_deployment_files(
             )
 
 
-def find_helm_updates(files):
-    updates = kustomize_files_find_helm_charts_with_updates(files)
+def find_helm_updates(files, ignored_images: set[str]):
+    updates = kustomize_files_find_helm_charts_with_updates(files, ignored_images)
     return updates
 
 
-def find_chart_updates(files):
-    updates = chart_files_find_chart_updates(files)
+def find_chart_updates(files, ignored_images: set[str]):
+    updates = chart_files_find_chart_updates(files, ignored_images)
     return updates
 
 
@@ -57,14 +57,14 @@ def find_image_updates(files, ignored_images: set[str]):
     return updates
 
 
-def kustomize_files_find_helm_charts_with_updates(kustomize_files):
+def kustomize_files_find_helm_charts_with_updates(kustomize_files, ignored_images: set[str]):
     files_needing_updates = []
     for kustomize_file in kustomize_files:
         file_stream = io.BytesIO(kustomize_file.decoded_content)
         try:
             parsed_file = yaml.safe_load(file_stream)
             if "helmCharts" in parsed_file:
-                updated_file = check_for_helm_chart_update(parsed_file)
+                updated_file = check_for_helm_chart_update(parsed_file, ignored_images)
                 if updated_file is not None:
                     updated_file["path"] = kustomize_file.path
                     updated_file["sha"] = kustomize_file.sha
@@ -74,13 +74,13 @@ def kustomize_files_find_helm_charts_with_updates(kustomize_files):
     return files_needing_updates
 
 
-def chart_files_find_chart_updates(chart_files):
+def chart_files_find_chart_updates(chart_files, ignored_images: set[str]):
     files_needing_updates = []
     for chart_file in chart_files:
         file_stream = io.BytesIO(chart_file.decoded_content)
         try:
             parsed_file = yaml.safe_load(file_stream)
-            updated_file = check_for_chart_update(parsed_file)
+            updated_file = check_for_chart_update(parsed_file, ignored_images)
             if updated_file is not None:
                 updated_file["path"] = chart_file.path
                 updated_file["sha"] = chart_file.sha

--- a/jobs/service_update/main.py
+++ b/jobs/service_update/main.py
@@ -58,9 +58,9 @@ def main():
         ignored_images = get_ignored_images()
 
         logger.info("Checking for updates")
-        helm_updates = find_helm_updates(kustomize_files)
+        helm_updates = find_helm_updates(kustomize_files, ignored_images)
         image_updates = find_image_updates(deployment_files, ignored_images)
-        chart_updates = find_chart_updates(chart_files)
+        chart_updates = find_chart_updates(chart_files, ignored_images)
 
         if not (helm_updates or image_updates or chart_updates):
             logger.info("Found no charts or images to update")

--- a/jobs/service_update/pyproject.toml
+++ b/jobs/service_update/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "service-update"
-version = "1.1.8"
+version = "1.1.9"
 description = "Service update job for k8s deployments"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
The ignored_images config setting was only checked against container images in deployment.yaml files. Helm chart dependencies (e.g. postgresql in Chart.yaml) were never checked against it.