### PR TITLE
Service update improvements: config service integration, chart filtering, SHA fix

### DIFF
--- a/jobs/service_update/update_handlers.py
+++ b/jobs/service_update/update_handlers.py
@@ -137,7 +137,9 @@ def commit_updates_to_branch(
     target_branch_ref,
     files_needing_updates,
 ):
+    branch_name = target_branch_ref.replace("refs/heads/", "")
     for file in files_needing_updates:
+        current_sha = argo_repo.get_contents(file["path"], ref=branch_name).sha
         if "kustomize_file" in file:
             file_content_stream = io.StringIO()
             yaml.dump(file["kustomize_file"], file_content_stream)
@@ -147,7 +149,7 @@ def commit_updates_to_branch(
                 file["path"],
                 f"Bump {file['release_name']} version to {file['new_version']}",
                 file_contents,
-                file["sha"],
+                current_sha,
                 target_branch_ref,
             )
         elif "deployment_file" in file:
@@ -158,7 +160,7 @@ def commit_updates_to_branch(
                 file["path"],
                 f"Bump {file['image_name']} image tag to {file['new_tag']}",
                 file_content_stream.getvalue(),
-                file["sha"],
+                current_sha,
                 target_branch_ref,
             )
         elif "chart_file" in file:
@@ -169,7 +171,7 @@ def commit_updates_to_branch(
                 file["path"],
                 f"Bump {file['chart_name']} version to {file['new_version']}",
                 file_content_stream.getvalue(),
-                file["sha"],
+                current_sha,
                 target_branch_ref,
             )
         else:


### PR DESCRIPTION
## Summary
- Fetch ignored images/charts list from configuration-setting-service at runtime instead of a hardcoded set
- Apply ignored list to all three update paths (container images, Chart.yaml dependencies, kustomization.yaml helm charts)
- Replace case-sensitive keyword chart version filtering with a strict `X.Y.Z` / `X.Y.Z-stable` regex
- Fix 409 SHA conflict by fetching the live file SHA from the target branch before each commit
- Fix `uv pip install` by switching jobs-common source from workspace to path reference
- Add missing empty-version-list guard in `check_for_helm_chart_update`
- Build Docker images on PRs against main (without pushing)

## Test plan
- [ ] Docker build passes in CI for both jobs
- [ ] Ignored images/charts fetched from config service are respected
- [ ] No 409 errors on repeated same-day runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)